### PR TITLE
[BugFix] Properly handle whitespaces in AuthenticationChatPasswordListener 

### DIFF
--- a/core/src/main/java/me/mastercapexd/auth/listener/AuthenticationChatPasswordListener.java
+++ b/core/src/main/java/me/mastercapexd/auth/listener/AuthenticationChatPasswordListener.java
@@ -45,7 +45,7 @@ public class AuthenticationChatPasswordListener {
                 return true;
             }
             String confirmationPassword = messageParts[1];
-            if (confirmationPassword.equals(password)) {
+            if (!confirmationPassword.equals(password)) {
                 player.sendMessage(config.getServerMessages().getMessage("confirm-failed"));
                 return true;
             }

--- a/core/src/main/java/me/mastercapexd/auth/listener/AuthenticationChatPasswordListener.java
+++ b/core/src/main/java/me/mastercapexd/auth/listener/AuthenticationChatPasswordListener.java
@@ -2,29 +2,55 @@ package me.mastercapexd.auth.listener;
 
 import com.bivashy.auth.api.AuthPlugin;
 import com.bivashy.auth.api.account.Account;
+import com.bivashy.auth.api.config.PluginConfig;
 import com.bivashy.auth.api.event.PlayerChatPasswordEvent;
+import com.bivashy.auth.api.server.player.ServerPlayer;
+
 import io.github.revxrsal.eventbus.SubscribeEvent;
 import me.mastercapexd.auth.server.commands.impl.LoginCommandImplementation;
 import me.mastercapexd.auth.server.commands.impl.RegisterCommandImplementation;
 import me.mastercapexd.auth.server.commands.parameters.RegisterPassword;
 
 public class AuthenticationChatPasswordListener {
+
     private final AuthPlugin plugin;
+    private final PluginConfig config;
 
     public AuthenticationChatPasswordListener(AuthPlugin plugin) {
         this.plugin = plugin;
+        this.config = plugin.getConfig();
     }
 
     @SubscribeEvent
     public void onPlayerChatPassword(PlayerChatPasswordEvent e) {
+        String[] messageParts = e.getPassword().split("\\s+");
+        String password = messageParts[0];
         Account account = plugin.getAuthenticatingAccountBucket().getAuthenticatingAccountNullable(e.getPlayer());
 
         if (!account.isRegistered()) {
+            if (passwordConfirmationFailed(messageParts, password, e.getPlayer()))
+                return;
             RegisterCommandImplementation impl = new RegisterCommandImplementation(plugin);
-            impl.performRegister(e.getPlayer(), account, new RegisterPassword(e.getPassword()));
+            impl.performRegister(e.getPlayer(), account, new RegisterPassword(password));
         } else {
             LoginCommandImplementation impl = new LoginCommandImplementation(plugin);
-            impl.performLogin(e.getPlayer(), account, e.getPassword());
+            impl.performLogin(e.getPlayer(), account, password);
         }
     }
+
+    private boolean passwordConfirmationFailed(String[] messageParts, String password, ServerPlayer player) {
+        if (config.isPasswordConfirmationEnabled()) {
+            if (messageParts.length < 2) {
+                player.sendMessage(config.getServerMessages().getMessage("confirm-password"));
+                return true;
+            }
+            String confirmationPassword = messageParts[1];
+            if (confirmationPassword.equals(password)) {
+                player.sendMessage(config.getServerMessages().getMessage("confirm-failed"));
+                return true;
+            }
+        }
+        return false;
+    }
+
 }


### PR DESCRIPTION
## Pull Request Etiquette

<!--
  There are several guidelines you should follow in order for your
  Pull Request to be merged.
-->

- [X] I have checked the PRs for upcoming features/bug fixes.

<!--
  It is sometimes better to include more changes in a single commit. 
  If you find yourself having an overwhelming amount of commits, you
  can **rebase** your branch.
-->

### Changes

- [X] Internal code
- [ ] API (affecting end-user code)
- [ ] Other: \_____ <!-- Insert other type here -->

<!-- Replace "NaN" with an issue number if this is a response to an issue -->

Closes Issue: NaN

## Description

Fixes next 'bugs':
  - Player could accidentially register password with whiteline characters, for example if player would type into chat: 'password password', plugin will consider that as 'test test' password instead of 'test'
  - Password confirmation requirement such like in /register <pass> <pass_repeat> doesn't work on chat too. 
