### PR TITLE
[Fix] Relocate and download Caffeine using LibraryManagement

### DIFF
--- a/bungee/src/main/resources/bungee.yml
+++ b/bungee/src/main/resources/bungee.yml
@@ -6,5 +6,3 @@ softDepends:
   - JavaTelegramBotApi
   - NanoLimboBungee
 author: bivashy, MasterCapeXD
-libraries:
-  - com.github.ben-manes.caffeine:caffeine:3.1.7

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -124,7 +124,6 @@
         <dependency>
             <groupId>com.github.ben-manes.caffeine</groupId>
             <artifactId>caffeine</artifactId>
-            <version>3.1.7</version>
             <scope>provided</scope>
         </dependency>
     </dependencies>

--- a/core/src/main/java/me/mastercapexd/auth/management/BaseLibraryManagement.java
+++ b/core/src/main/java/me/mastercapexd/auth/management/BaseLibraryManagement.java
@@ -1,7 +1,7 @@
 package me.mastercapexd.auth.management;
 
 import java.util.ArrayList;
-import java.util.Collection;
+import java.util.Collections;
 import java.util.List;
 
 import com.alessiodp.libby.Library;
@@ -11,6 +11,7 @@ import com.bivashy.auth.api.management.LibraryManagement;
 public class BaseLibraryManagement implements LibraryManagement {
 
     private static final String JDA_VERSION = "5.0.0-beta.20";
+    private static final String CAFFEINE_VERSION = "3.1.8";
     public static final Library JDA_LIBRARY = Library.builder()
             .groupId("net{}dv8tion")
             .artifactId("JDA")
@@ -27,8 +28,17 @@ public class BaseLibraryManagement implements LibraryManagement {
             .resolveTransitiveDependencies(true)
             .excludeTransitiveDependency("club{}minnced", "opus-java")
             .build();
+    public static final Library CAFFEINE_LIBRARY = Library.builder()
+            .groupId("com{}github{}ben-manes{}caffeine")
+            .artifactId("caffeine")
+            .relocate("com{}github{}benmanes{}caffeine", "com{}bivashy{}auth{}lib{}com{}github{}benmanes{}caffeine")
+            .version(CAFFEINE_VERSION)
+            .resolveTransitiveDependencies(true)
+            .build();
     private final List<String> customRepositories = new ArrayList<>();
-    private final List<Library> customLibraries = new ArrayList<>();
+    private final List<Library> customLibraries = new ArrayList<>(Collections.singletonList(
+            CAFFEINE_LIBRARY
+    ));
     private final LibraryManager libraryManager;
 
     public BaseLibraryManagement(LibraryManager libraryManager) {
@@ -42,9 +52,7 @@ public class BaseLibraryManagement implements LibraryManagement {
         libraryManager.addMavenCentral();
         libraryManager.addJitPack();
 
-        Collection<Library> libraries = new ArrayList<>(customLibraries);
-
-        libraries.forEach(libraryManager::loadLibrary);
+        customLibraries.forEach(libraryManager::loadLibrary);
     }
 
     @Override

--- a/pom.xml
+++ b/pom.xml
@@ -65,6 +65,7 @@
         <event-bus.version>1.3</event-bus.version>
         <libby.version>2.0.0-SNAPSHOT</libby.version>
         <nanolimbo.version>1.0.8</nanolimbo.version>
+        <caffeine.version>3.1.8</caffeine.version>
 
         <!-- Maven plugins -->
         <maven.compiler.plugin.version>3.12.1</maven.compiler.plugin.version>
@@ -327,6 +328,11 @@
                 <artifactId>api</artifactId>
                 <version>${nanolimbo.version}</version>
             </dependency>
+            <dependency>
+                <groupId>com.github.ben-manes.caffeine</groupId>
+                <artifactId>caffeine</artifactId>
+                <version>${caffeine.version}</version>
+            </dependency>
         </dependencies>
     </dependencyManagement>
 
@@ -466,6 +472,10 @@
                         <relocation>
                             <pattern>com.grack.nanojson</pattern>
                             <shadedPattern>${dependencies.relocation.package}.com.grack.nanojson</shadedPattern>
+                        </relocation>
+                        <relocation>
+                            <pattern>com.github.benmanes.caffeine</pattern>
+                            <shadedPattern>${dependencies.relocation.package}.com.github.benmanes.caffeine</shadedPattern>
                         </relocation>
                     </relocations>
                 </configuration>


### PR DESCRIPTION
## Pull Request Etiquette

- [X] I have checked the PRs for upcoming features/bug fixes.

### Changes

- [X] Internal code
- [ ] API (affecting end-user code)
- [ ] Other: ___

Closes Issue: NaN

## Description

Tested with
  - **Waterfall** `git:Waterfall-Bootstrap:1.21-R0.1-SNAPSHOT:de8345a:579`
  - **Velocity** `Velocity 3.3.0-SNAPSHOT (git-9d25d309-b400)`
  
Changes:
  - Bumps caffeine version to `3.1.8` from `3.1.7`
  - Relocates `com.github.benmanes.caffeine`
  - Downloads Caffeine using `LibraryManagement`
  
**Why we are relocating caffeine?**
We are relocating caffeine to avoid conflicts with other plugins that use caffeine in their `IsolatedClassLoader`. Currently we are relocating in `pom.xml` and when downloading the library using `libby`.
  
**Why are we downloading caffeine in Velocity when it already exists in classpath?**
I am aware that caffeine already exists in the Velocity classpath, but we cannot be sure that caffeine will not be deleted/isolated/relocated in future Velocity releases, so we do not rely on Velocity libraries.